### PR TITLE
Add PC server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,14 @@ Ein barrierefreier Rampenrechner mit Unterstützung für internationale Normen, 
 ```bash
 npm install
 npm run dev
+```
+
+## PC-Server
+
+Der Python-Server im Ordner `pc-server` wird wie folgt vorbereitet und gestartet:
+
+```bash
+cd pc-server
+pip install -r requirements.txt
+python server.py
+```

--- a/pc-server/requirements.txt
+++ b/pc-server/requirements.txt
@@ -1,0 +1,1 @@
+pybluez


### PR DESCRIPTION
## Summary
- add `pc-server/requirements.txt` with pybluez
- document how to set up and run the Python server in README

## Testing
- `apt-get update`
- `apt-get install -y ed`

------
https://chatgpt.com/codex/tasks/task_e_6840c5c6a7f88324a7941eccc6b92144