### PR TITLE
Add DIN/EU slope checks with docs and demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,28 @@ Ein barrierefreier Rampenrechner mit Unterstützung für internationale Normen, 
 - ✅ PDF / E-Mail / LocalStorage
 - ✅ Getestet mit Vitest + GitHub Actions
 
+## Steigungsbewertung
+
+Die Funktion `checkRampAgainstNorms` prüft die Steigung einer Rampe anhand
+gängiger DIN- und EU‑Vorgaben:
+
+- **bis 6 %** → *ideal*: voll normkonform
+- **bis 8 %** → *akzeptabel*: nur für kurze Rampen zulässig
+- **über 8 %** → *zu steil*: nicht konform
+
+Zur Nutzung in einer Anwendung kann die Funktion wie folgt aufgerufen werden:
+
+```ts
+import { checkRampAgainstNorms } from './src/norms.js';
+
+const result = checkRampAgainstNorms(7.5);
+console.log(result.rating); // "acceptable"
+console.log(result.messages.join('\n'));
+```
+
+Das zurückgegebene Objekt enthält sowohl eine Bewertung als auch erläuternde
+Texte für Benutzerinnen und Benutzer.
+
 ## Starten
 
 ```bash

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,17 @@ import { calculateRampLength } from './ramp.js';
 import { checkRampAgainstNorms } from './norms.js';
 
 export function demo() {
-  const length = calculateRampLength(1, 12);
-  const result = checkRampAgainstNorms(8.3);
-  console.log('Ramp length:', length.toFixed(2));
-  console.log('Norm result:', result);
+  const rise = 1; // in meters
+  const run = 12; // in meters
+  const length = calculateRampLength(rise, run);
+  const slopePercent = (rise / run) * 100;
+  const result = checkRampAgainstNorms(slopePercent);
+
+  console.log(`Ramp rise/run: ${rise}m / ${run}m`);
+  console.log(`Slope: ${slopePercent.toFixed(1)}%`);
+  console.log(`Length: ${length.toFixed(2)}m`);
+  console.log(`Rating: ${result.rating}`);
+  console.log(result.messages.join('\n'));
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/src/norms.ts
+++ b/src/norms.ts
@@ -1,12 +1,41 @@
 export interface NormCheckResult {
+  /** Whether the given slope meets at least the minimum requirements */
   isCompliant: boolean;
+  /** Detailed explanation for the user */
   messages: string[];
+  /** Overall rating according to the norms */
+  rating: 'ideal' | 'acceptable' | 'too steep';
 }
 
+/**
+ * Validate a ramp slope according to DIN 18040 and common EU guidance.
+ *
+ * - <= 6% is considered ideal and fully compliant
+ * - > 6% and <= 8% is acceptable only for short ramps
+ * - > 8% is non‑compliant
+ */
 export function checkRampAgainstNorms(slope: number): NormCheckResult {
-  // Placeholder always compliant
+  const messages: string[] = [];
+  let rating: 'ideal' | 'acceptable' | 'too steep';
+
+  if (slope <= 6) {
+    rating = 'ideal';
+    messages.push(
+      'Complies with DIN 18040 and EU recommendations (<=6% slope)'
+    );
+  } else if (slope <= 8) {
+    rating = 'acceptable';
+    messages.push(
+      'Acceptable according to DIN 18040/EU for short ramps (<=8% slope)'
+    );
+  } else {
+    rating = 'too steep';
+    messages.push('Exceeds DIN 18040/EU maximum recommended slope');
+  }
+
   return {
-    isCompliant: true,
-    messages: ['Norm checks not yet implemented']
+    isCompliant: rating !== 'too steep',
+    messages,
+    rating
   };
 }


### PR DESCRIPTION
## Summary
- implement DIN/EU-based ramp slope validation
- document how slopes are rated
- show a clearer demo output

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: cannot find name 'process' without node types)*
- `npm run dev` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851ff26e09c8324a8a78506d6cfcd9d